### PR TITLE
Tailscale experiment

### DIFF
--- a/tailscale/client/src/App.tsx
+++ b/tailscale/client/src/App.tsx
@@ -156,17 +156,17 @@ export function App() {
   }
 
   function DisplayTailscaleIPs(container: Container) {
-    let ips: string[] = [];
-
-    if (status !== undefined) {
-      for (var i = 0; i < status?.Self.TailscaleIPs.length; i++) {
-        ips.push(status?.Self.TailscaleIPs[i]);
-      }
+    if (status == undefined) {
+      return;
     }
 
     return (
-      <td key={'ips-' + container.Names[0]}>
-        {ips.length > 0 ? ips.map((i) => <pre>{i}</pre>) : <pre>-</pre>}
+      <td key={'ip-' + container.Names[0]}>
+        {status?.Self.TailscaleIPs.length > 0 ? (
+          <pre>{status?.Self.TailscaleIPs[0]}</pre>
+        ) : (
+          <pre>-</pre>
+        )}
       </td>
     );
   }


### PR DESCRIPTION
This PR displays the list of containers that are exposed within the Tailscale network.

![image](https://user-images.githubusercontent.com/15997951/135257229-3088a747-4a1d-48e6-acfe-8b7abf41279c.png)
TODO:

- [x] Display containers in a table
- [x]  Disable connect button if user is already logged in
- [x] If no magic dns, display ip instead
- [x] Refresh status and list containers when clicking on the Tailscale tab
