### PR TITLE
No need to cat metadata for all plugins; can use FROM scratch if no VM service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-all: 
-	cd swimmingwhale ; docker build -t simmingwhale .
-	cd tailscale ; make plugin
-	cd telepresence ; make plugin
-	cd vm-ui-plugin ; make plugin

--- a/swimmingwhale/Dockerfile
+++ b/swimmingwhale/Dockerfile
@@ -1,7 +1,5 @@
-FROM alpine:3.14.2
+FROM scratch
 
 COPY docker.svg .
 COPY ui ./swim
 COPY metadata.json .
-
-CMD cat /metadata.json

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update
 RUN apt-get install -y wget tar iptables iproute2
 ENV TSFILE=tailscale_1.14.3_amd64.tgz
 RUN wget https://pkgs.tailscale.com/stable/${TSFILE} && \
-    tar xzf ${TSFILE} --strip-components=1
+    tar xzf ${TSFILE} --strip-components=1 && \
+    rm ${TSFILE}
 
 WORKDIR /
 COPY vm/docker-compose.yaml .
@@ -27,4 +28,4 @@ COPY --from=client-builder /app/client/dist ui
 COPY tailscale.svg .
 COPY metadata.json .
 
-CMD cat /metadata.json
+CMD /app/tailscaled --state=tailscaled.state --tun=userspace-networking

--- a/tailscale/vm/docker-compose.yaml
+++ b/tailscale/vm/docker-compose.yaml
@@ -2,4 +2,3 @@ services:
   desktop-tailscale:
     container_name: tailscale_service
     image: ${DESKTOP_PLUGIN_IMAGE}
-    command: "/app/tailscaled --state=tailscaled.state --tun=userspace-networking"

--- a/telepresence/Dockerfile
+++ b/telepresence/Dockerfile
@@ -11,7 +11,7 @@ COPY client /app/client
 RUN yarn
 RUN yarn build
 
-FROM debian:bullseye
+FROM debian:bullseye as telepresence-builder
 
 RUN apt-get update
 RUN apt-get install -y curl tar
@@ -19,8 +19,9 @@ RUN mkdir /darwin
 RUN curl -fL https://app.getambassador.io/download/tel2/darwin/amd64/latest/telepresence -o /darwin/telepresence
 RUN chmod a+x /darwin/telepresence
 
+FROM scratch
 WORKDIR /
 COPY --from=client-builder /app/client/dist ui
-COPY metadata.json .
+COPY --from=telepresence-builder /darwin/telepresence /darwin/
 
-CMD cat /metadata.json
+COPY metadata.json .

--- a/vm-ui-plugin/Dockerfile
+++ b/vm-ui-plugin/Dockerfile
@@ -11,4 +11,4 @@ COPY vm-main/docker-compose.yaml .
 COPY metadata.json .
 COPY client/src ./plugin-ui
 
-CMD cat /metadata.json
+CMD /volume-service -socket /run/guest-services/plugin-experiment.sock

--- a/vm-ui-plugin/vm-main/docker-compose.yaml
+++ b/vm-ui-plugin/vm-main/docker-compose.yaml
@@ -1,7 +1,6 @@
 services:
   devenv-volumes:
     image: ${DESKTOP_PLUGIN_IMAGE}
-    command: /volume-service -socket /run/guest-services/plugin-experiment.sock
     cap_add:
       - DAC_OVERRIDE
       - FOWNER


### PR DESCRIPTION
Can use "FROM scratch" base image, more use of multi-stage build. 
tailscale image 200M => 29 M, telerepsence image 284M => 67M

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>