### PR TITLE
specify grpc port for demo

### DIFF
--- a/telepresence/client/src/App.tsx
+++ b/telepresence/client/src/App.tsx
@@ -108,7 +108,7 @@ export function App() {
     );
     window.ddClient
       .execHostCmd(
-        `telepresence intercept ${serviceName} --port 8081 -n ${namespace}`,
+        `telepresence intercept ${serviceName} --port 8081:grpc -n ${namespace}`,
       )
       .then((value: any) => {
         console.log(value.stdout);


### PR DESCRIPTION
This PR hard-codes the GRPC port so the voting service can be intercepted from the UI.

It fixes this issue:

```cli
Error: Error invoking remote method 'telepresence-exec-cmd': Error: Command failed: /Users/felipecruz/Library/Containers/com.docker.docker/Data/plugins/telepresence/host/telepresence intercept voting --port 8081 -n default
telepresence: error: Failed to establish intercept: Deployment name="voting" namespace="default": found matching Service with multiple matching ports.
Please specify the Service port you want to intercept by passing the --port=local:svcPortName flag.

See logs for details (4 errors found): "/Users/felipecruz/Library/Logs/telepresence/daemon.log"

See logs for details (4 errors found): "/Users/felipecruz/Library/Logs/telepresence/connector.log"
If you think you have encountered a bug, please run `telepresence gather-logs` and attach the telepresence_logs.zip to your github issue.
```