### PR TITLE
telepresence: Make multiarch

### DIFF
--- a/telepresence/Dockerfile
+++ b/telepresence/Dockerfile
@@ -1,42 +1,44 @@
+#syntax=docker/dockerfile:1.3-labs
+
 FROM node:14.17-alpine3.13 AS client-builder
 
 WORKDIR /app/client
 # cache packages in layer
 COPY client/package.json /app/client/package.json
 COPY client/yarn.lock /app/client/yarn.lock
+ARG TARGETARCH
+RUN yarn config set cache-folder /usr/local/share/.cache/yarn-${TARGETARCH}
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn-${TARGETARCH} yarn
 # install
-RUN yarn
 COPY client /app/client
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn-${TARGETARCH} yarn build
 
-RUN yarn
-RUN yarn build
-
-FROM debian:bullseye as telepresence-builder
-
-RUN apt-get update
-RUN apt-get install -y curl tar
-RUN mkdir /darwin
-RUN curl -fL https://app.getambassador.io/download/tel2/darwin/amd64/latest/telepresence -o /darwin/telepresence
-RUN chmod a+x /darwin/telepresence
-RUN mkdir /windows
-RUN curl -fL https://app.getambassador.io/download/tel2/windows/amd64/latest/telepresence.zip -o /windows/telepresence.zip
-RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/windows/amd64/kubectl.exe" -o /windows/kubectl.exe
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
-RUN chmod a+x kubectl
-RUN mv ./kubectl /darwin/kubectl
+FROM alpine AS dl
+WORKDIR /tmp
+RUN apk add --no-cache curl tar
+ARG TARGETARCH
+RUN <<EOT ash
+    mkdir -p /out/darwin
+    curl -fSsLo /out/darwin/telepresence      https://app.getambassador.io/download/tel2/darwin/${TARGETARCH}/latest/telepresence
+    chmod a+x /out/darwin/telepresence
+    curl -fSsLo /out/darwin/kubectl          "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/darwin/${TARGETARCH}/kubectl"
+    chmod a+x /out/darwin/kubectl
+EOT
+RUN <<EOT ash
+    if [ "amd64" = "$TARGETARCH" ]; then
+        mkdir -p /out/windows
+        curl -fSsLo /out/windows/telepresence.zip https://app.getambassador.io/download/tel2/windows/amd64/latest/telepresence.zip
+        curl -fSsLo /out/windows/kubectl.exe     "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/windows/amd64/kubectl.exe"
+    fi
+EOT
 
 FROM scratch
-
 LABEL org.opencontainers.image.title="Telepresence" \
     org.opencontainers.image.authors="Datawire" \
     com.docker.desktop.plugin.api.version="1.0.0-beta.1"
 
-WORKDIR /
 COPY --from=client-builder /app/client/dist ui
-COPY --from=telepresence-builder /darwin/telepresence /darwin/
-COPY --from=telepresence-builder /windows/telepresence.zip /windows/
-COPY --from=telepresence-builder /windows/kubectl.exe /windows/
-COPY --from=telepresence-builder /darwin/kubectl /darwin/
+COPY --from=dl /out /
 
 COPY telepresence-win-install.ps1 /windows
 COPY metadata.json .

--- a/telepresence/Makefile
+++ b/telepresence/Makefile
@@ -4,6 +4,7 @@ ifeq ($(OS),Windows_NT)
 endif
 
 BUILDER=buildx-multi-arch
+IMG_PREFIX=docker/
 
 STATIC_FLAGS=CGO_ENABLED=0
 #GIT_TAG?=$(shell git describe --tags --match "[0-9]*")
@@ -22,7 +23,7 @@ plugin: ## Build service image to be deployed as a desktop plugin
 	docker build --tag=desktop-telepresence-plugin .
 
 push-plugin: prepare-buildx ## Build & Upload plugin image to hub. Do not push if tag already exists: make push-plugin tag=0.1
-	docker pull docker/desktop-telepresence-plugin:$(tag) && echo "Failure: Tag already exists" || docker buildx build --push --builder=$(BUILDER) --platform=linux/amd64,linux/arm64 --build-arg TAG=${tag)} --tag=docker/desktop-telepresence-plugin:$(tag) .
+	docker pull $(IMG_PREFIX)desktop-telepresence-plugin:$(tag) && echo "Failure: Tag already exists" || docker buildx build --push --builder=$(BUILDER) --platform=linux/amd64,linux/arm64 --build-arg TAG=$(tag) --tag=$(IMG_PREFIX)desktop-telepresence-plugin:$(tag) .
 
 help: ## Show this help
 	@echo Please specify a build target. The choices are:


### PR DESCRIPTION
You can test this locally by doing the following:
```console
$ cd telepresence
$ docker run --rm -d -p 5001:5000 registry:2
$ make IMG_PREFIX=localhost:5001/ push-plugin
```

*Note:* that the image will be pushed to your locally running registry.

```console
$ docker buildx imagetools inspect localhost:5001/desktop-telepresence-plugin:0.0.1
Name:      localhost:5001/desktop-telepresence-plugin:0.0.1
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:074e2a272edf248503db1b67cae6cb4d61ba2eb7b98e5d66e0aa224076b1dfba
           
Manifests: 
  Name:      localhost:5001/desktop-telepresence-plugin:0.0.1@sha256:51a306420c8d8130fbeacd85deb3830e79bc68f73cd6b4051faf95d0e0e0b24c
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64
             
  Name:      localhost:5001/desktop-telepresence-plugin:0.0.1@sha256:5f9aeb5fe2f1e6ff0c881ce9fb27a3fbc0ff7272eb5ae620c432abee3f9ff414
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
```