### PR TITLE
tailscale: set environment variable for HostInfo

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -34,4 +34,5 @@ COPY vm/docker-compose.yaml .
 COPY --from=client-builder /app/client/dist ui
 COPY tailscale.svg .
 COPY metadata.json .
+ENV TS_HOST_ENV dde
 CMD /app/tailscaled --state=tailscaled.state --tun=userspace-networking


### PR DESCRIPTION
Set TS_HOST_ENV=dde, which tailscaled can use to report itself
as running in Docker Desktop (it doesn't do anything differently,
just reporting for metrics).