### PR TITLE
tailscale: set hostname to "docker-desktop"

### DIFF
--- a/tailscale/client/src/App.tsx
+++ b/tailscale/client/src/App.tsx
@@ -39,7 +39,7 @@ export function App() {
     window.ddClient.backend
       .execInContainer(
         'tailscale_service',
-        `/app/tailscale up --authkey ${token}`,
+        `/app/tailscale up --authkey ${token} --hostname=docker-desktop`,
       )
       .then(() => updateStatus());
   }


### PR DESCRIPTION
The hostname of the Desktop VM is a hex string and not
likely to be meaningful.

If a single User account is running Docker Desktop on multiple
systems, subsequent devices will be automatically renamed
"docker-desktop-1", "docker-desktop-2", etc. This still seems
reasonable for such a case.