### PR TITLE
Add `org.opencontainers.image.description` to extensions

### DIFF
--- a/swimmingwhale/Dockerfile
+++ b/swimmingwhale/Dockerfile
@@ -1,6 +1,7 @@
 FROM scratch
 
 LABEL org.opencontainers.image.title="SwimmingWhale" \
+    org.opencontainers.image.description="A sample plugin that just displays a whale swimming." \
     org.opencontainers.image.authors="Docker Inc." \
     com.docker.desktop.plugin.api.version="1.0.0-beta.1"
 

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -20,6 +20,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn-${TARGETARCH} yarn bu
 
 FROM debian:bullseye-slim
 LABEL org.opencontainers.image.title="Tailscale" \
+    org.opencontainers.image.description="Expose your Docker containers to a secure VPN in one click." \
     org.opencontainers.image.authors="Tailscale Inc." \
     com.docker.desktop.plugin.api.version="1.0.0-beta.1"
 RUN apt-get update \

--- a/telepresence/Dockerfile
+++ b/telepresence/Dockerfile
@@ -34,6 +34,7 @@ EOT
 
 FROM scratch
 LABEL org.opencontainers.image.title="Telepresence" \
+    org.opencontainers.image.description="Develop locally and Intercept traffic from your Kubernetes cluster." \  
     org.opencontainers.image.authors="Datawire" \
     com.docker.desktop.plugin.api.version="1.0.0-beta.1"
 

--- a/vm-ui-plugin/Dockerfile
+++ b/vm-ui-plugin/Dockerfile
@@ -8,6 +8,7 @@ RUN make bin
 FROM alpine
 
 LABEL org.opencontainers.image.title="volume-sample" \
+    org.opencontainers.image.description="A sample plugin that lists all Docker volumes." \
     org.opencontainers.image.authors="Docker Inc." \
     com.docker.desktop.plugin.api.version="1.0.0-beta.1"
 

--- a/volumes-share/server/Dockerfile
+++ b/volumes-share/server/Dockerfile
@@ -10,6 +10,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM alpine
 
 LABEL org.opencontainers.image.title="volumes-share" \
+    org.opencontainers.image.description="A sample plugin to push/pull volumes as images to DockerHub." \
     org.opencontainers.image.authors="Docker Inc." \
     com.docker.desktop.plugin.api.version="1.0.0-beta.1"
 


### PR DESCRIPTION
This is the first part of the following Notion ticket: https://www.notion.so/dockerinc/Fetch-title-provider-and-description-from-the-image-labels-e9e5d0b7e46e4d8eb5b5d53ea6cd086c.

Before fetching some information from Desktop Extensions, we need to have them defined as labels.
