### PR TITLE
Fix tailscale image labels and add icon

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -19,7 +19,8 @@ COPY client /app/client
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn-${TARGETARCH} yarn build
 
 FROM debian:bullseye-slim
-LABEL org.opencontainers.image.title="Tailscale" \
+LABEL org.opencontainers.image.title="tailscale" \
+    com.docker.desktop.plugin.icon="https://f-droid.org/repo/icons-640/com.tailscale.ipn.78.png" \
     org.opencontainers.image.description="Expose your Docker containers to a secure VPN in one click." \
     org.opencontainers.image.authors="Tailscale Inc." \
     com.docker.desktop.plugin.api.version="1.0.0-beta.1"


### PR DESCRIPTION
Image title label must match the extension name in metadata for now (will be more flexible later on)
Added an icon in image labels