### PR TITLE
tailscale: update copy for extension

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn-${TARGETARCH} yarn bu
 FROM debian:bullseye-slim
 LABEL org.opencontainers.image.title="tailscale" \
     com.docker.desktop.plugin.icon="https://f-droid.org/repo/icons-640/com.tailscale.ipn.78.png" \
-    org.opencontainers.image.description="Expose your Docker containers to a secure VPN in one click." \
+    org.opencontainers.image.description="Connect your Docker containers to your secure private network." \
     org.opencontainers.image.authors="Tailscale Inc." \
     com.docker.desktop.plugin.api.version="1.0.0-beta.1"
 RUN apt-get update \

--- a/tailscale/client/src/App.tsx
+++ b/tailscale/client/src/App.tsx
@@ -47,7 +47,7 @@ export function App() {
 
   function disconnect() {
     console.log(
-      `Disconnects from Tailscale. When disconnected, you cannot reach devices over Tailscale.`,
+      `Disconnects from Tailscale, but keeps you logged in. When disconnected, you cannot reach devices over Tailscale.`,
     );
     window.ddClient.backend
       .execInVMExtension(`/app/tailscale down`)
@@ -56,7 +56,7 @@ export function App() {
 
   function logout() {
     console.log(
-      `Log out disconnects from Tailscale and expires the current log in. The next time you run tailscale up, you'll need to reauthenticate your device.`,
+      `Logs out from Tailscale. The next time you connect to Tailscale, you'll need to reauthenticate.`,
     );
     window.ddClient.backend
       .execInVMExtension(`/app/tailscale logout`)
@@ -96,7 +96,7 @@ export function App() {
   function PrintTableHeaders() {
     return (
       <tr key="headers">
-        {['Container', 'Published ports', 'Tailscale URL', 'Tailscale IP'].map(
+        {['Container', 'Published ports', 'Tailscale machine details URL', 'Tailscale IP'].map(
           (h) => (
             <td key={h}>{h}</td>
           ),
@@ -211,15 +211,22 @@ export function App() {
   return (
     <div>
       <div style={{ textAlign: 'center' }}>
-        <h1>Containers and teams, connected in one seamless experience.</h1>
+        <h1>
+          Containers in your Tailscale network
+        </h1>
         <h2>
-          We bring containers and teams closer, connecting them under a secure
-          private network, powered by Tailscale.
+          Connect your Docker containers to your secure private network.
         </h2>
-        <h4>
+        <p>
+          Tailscale connects your devices together, so you can access them
+          on your own private network.
+        </p>
+        <p>
           Your containers will be visible only to other devices on the same
-          Tailscale network.
-        </h4>
+          Tailscale network, as permitted by
+          <a href="https://login.tailscale.com/admin/acls">ACLs</a> in your
+          network.
+        </p>
       </div>
       <div>
         {(status === undefined ||

--- a/tailscale/tailscale.svg
+++ b/tailscale/tailscale.svg
@@ -1,11 +1,11 @@
 <svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="45.6297" cy="60.5186" r="6.62966" fill="#141414"/>
-<circle cx="65.5186" cy="60.5186" r="6.62966" fill="#141414"/>
-<circle opacity="0.2" cx="45.6297" cy="80.4077" r="6.62966" fill="#141414"/>
-<circle opacity="0.2" cx="85.4077" cy="80.4077" r="6.62966" fill="#141414"/>
-<circle cx="65.5186" cy="80.4077" r="6.62966" fill="#141414"/>
-<circle cx="85.4077" cy="60.5186" r="6.62966" fill="#141414"/>
-<circle opacity="0.2" cx="45.6297" cy="40.6297" r="6.62966" fill="#141414"/>
-<circle opacity="0.2" cx="65.5186" cy="40.6297" r="6.62966" fill="#141414"/>
-<circle opacity="0.2" cx="85.4077" cy="40.6297" r="6.62966" fill="#141414"/>
+<circle cx="40.625" cy="59.5" r="6.625" fill="#141414"/>
+<circle cx="60.4999" cy="59.5" r="6.625" fill="#141414"/>
+<circle opacity="0.2" cx="40.625" cy="79.375" r="6.625" fill="#141414"/>
+<circle opacity="0.2" cx="80.375" cy="79.375" r="6.625" fill="#141414"/>
+<circle cx="60.4999" cy="79.375" r="6.625" fill="#141414"/>
+<circle cx="80.375" cy="59.5" r="6.625" fill="#141414"/>
+<circle opacity="0.2" cx="40.625" cy="39.625" r="6.625" fill="#141414"/>
+<circle opacity="0.2" cx="60.4999" cy="39.625" r="6.625" fill="#141414"/>
+<circle opacity="0.2" cx="80.375" cy="39.625" r="6.625" fill="#141414"/>
 </svg>


### PR DESCRIPTION
This updates the copy for the Tailscale extension. Copy for a signed in user should focus more on what they are doing than on explaining the product.

This is likely to change again as we design (1) zero-state, (2) signed in but no machines, and (3) machines (this) view.

Not yet able to test locally.