### PR TITLE
Use host network for tailscale VM extension

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn-${TARGETARCH} yarn bu
 
 FROM debian:bullseye-slim
 LABEL org.opencontainers.image.title="tailscale" \
-    com.docker.desktop.plugin.icon="https://f-droid.org/repo/icons-640/com.tailscale.ipn.78.png" \
+    com.docker.desktop.extension.icon="https://f-droid.org/repo/icons-640/com.tailscale.ipn.78.png" \
     org.opencontainers.image.description="Connect your Docker containers to your secure private network." \
     org.opencontainers.image.authors="Tailscale Inc." \
     org.opencontainers.image.vendor="Tailscale Inc." \
@@ -37,6 +37,7 @@ COPY --from=tailscale /out/tailscaled /app/tailscaled
 COPY --from=client-builder /app/client/dist ui
 COPY tailscale.svg .
 COPY metadata.json .
+COPY vm/docker-compose.yaml .
 COPY host/hostname darwin/hostname
 COPY host/hostname.cmd windows/hostname.cmd
 ENV TS_HOST_ENV dde

--- a/tailscale/metadata.json
+++ b/tailscale/metadata.json
@@ -4,7 +4,7 @@
     "provider": "Tailscale Inc.",
     "icon":"tailscale.svg",
     "vm": {
-        "image":"${DESKTOP_PLUGIN_IMAGE}"
+        "composefile":"docker-compose.yaml"
     },
     "ui":{
         "dashboard-tab":

--- a/tailscale/vm/docker-compose.yaml
+++ b/tailscale/vm/docker-compose.yaml
@@ -1,0 +1,4 @@
+services:
+  desktop-tailscale:
+    network_mode: "host"
+    image: ${DESKTOP_PLUGIN_IMAGE}


### PR DESCRIPTION
This fixes a bug in most recent build of DD, where tailscale VM service was not able to contact ports exposed by other containers in the VM. 
It also makes sense that the Tailscale service runs in the VM network and not in its own isolated container network.
(Possibly linked to https://github.com/docker/for-mac/issues/5588#issuecomment-934600089)

Moving to using a compose file to specify host_network option when running the Tailscale VM service (using "host" network inside the VM, not native mac/windows host).

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>