### PR TITLE
Remove obsolete `desktop-plugin-version` from all metadata samples & docs

### DIFF
--- a/docs/extensions/METADATA.md
+++ b/docs/extensions/METADATA.md
@@ -19,14 +19,12 @@ The metadata.json file must follow the format :
     "name": "volumes-share",
     "provider": "Docker Inc.",
     "icon": "extension-icon.svg",
-    "desktop-plugin-version": "v1.0.0-beta.1",
     "ui": ...
     "vm": ...
     "host": ...
 }
 ```
 
-`desktop-plugin-version` is the version of the Extension API (using semver format) that the extension is compatible with.
 `ui`, `vm` and `host` sections are optional, depending what a given extension provides, and describe the extension content to be installed.
 
 The `ui` section defines a new tab that will be added to Docker Dashboard. (other UI extension points will likely be available in the future). It follows the form:

--- a/docs/tutorials/minimal-backend-extension.md
+++ b/docs/tutorials/minimal-backend-extension.md
@@ -58,7 +58,6 @@ A `metadata.json` file is required at the root of the image filesystem.
 
 ```json title="metadata.json" linenums="1"
 {
-  "desktop-plugin-version": "1.0.0-beta.1",
   "name": "hello-backend",
   "provider": "Docker Inc.",
   "vm": {

--- a/docs/tutorials/minimal-frontend-extension.md
+++ b/docs/tutorials/minimal-frontend-extension.md
@@ -51,7 +51,6 @@ A `metadata.json` file is required at the root of the image filesystem.
 
 ```json title="metadata.json" linenums="1"
 {
-  "desktop-plugin-version": "1.0.0-beta.1",
   "name": "MyExtension",
   "provider": "Docker Inc.",
   "ui": {

--- a/docs/tutorials/minimal-frontend-using-docker-cli.md
+++ b/docs/tutorials/minimal-frontend-using-docker-cli.md
@@ -52,7 +52,6 @@ A `metadata.json` file is required at the root of the image filesystem.
 
 ```json title="metadata.json" linenums="1"
 {
-  "desktop-plugin-version": "1.0.0-beta.1",
   "name": "MyExtension",
   "provider": "Docker Inc.",
   "ui": {

--- a/docs/tutorials/react-extension.md
+++ b/docs/tutorials/react-extension.md
@@ -70,7 +70,6 @@ A `metadata.json` file is required at the root of your extension directory.
 
 ```json title="metadata.json" linenums="1"
 {
-  "desktop-plugin-version": "1.0.0-beta.1",
   "name": "ui-extension",
   "provider": "Docker Inc.",
   "icon": "docker.svg",

--- a/minimal-backend/metadata.json
+++ b/minimal-backend/metadata.json
@@ -1,5 +1,4 @@
 {
-  "desktop-plugin-version": "1.0.0-beta.1",
   "name": "hello-backend",
   "provider": "Docker Inc.",
   "vm": {

--- a/minimal-docker-cli/metadata.json
+++ b/minimal-docker-cli/metadata.json
@@ -1,5 +1,4 @@
 {
-  "desktop-plugin-version": "1.0.0-beta.1",
   "name": "MyExtension",
   "provider": "Docker Inc.",
   "ui": {

--- a/minimal-frontend/metadata.json
+++ b/minimal-frontend/metadata.json
@@ -1,5 +1,4 @@
 {
-  "desktop-plugin-version": "1.0.0-beta.1",
   "name": "MyExtension",
   "provider": "Docker Inc.",
   "ui": {

--- a/react-extension/metadata.json
+++ b/react-extension/metadata.json
@@ -1,5 +1,4 @@
 {
-  "desktop-plugin-version": "1.0.0-beta.1",
   "name": "ui-extension",
   "provider": "Docker Inc.",
   "icon": "docker.svg",

--- a/swimmingwhale/metadata.json
+++ b/swimmingwhale/metadata.json
@@ -1,5 +1,4 @@
 {
-    "desktop-plugin-version": "1.0.0-beta.1",
     "name":"SwimmingWhale",
     "provider": "Docker Inc.",
     "icon": "docker.svg",

--- a/tailscale/metadata.json
+++ b/tailscale/metadata.json
@@ -1,5 +1,4 @@
 {
-    "desktop-plugin-version": "1.0.0-beta.1",
     "name":"tailscale",
     "provider": "Tailscale Inc.",
     "icon":"tailscale.svg",

--- a/telepresence/metadata.json
+++ b/telepresence/metadata.json
@@ -1,5 +1,4 @@
 {
-  "desktop-plugin-version": "1.0.0-beta.1",
   "name": "telepresence",
   "ui": {
     "dashboard-tab": {

--- a/vm-ui-plugin/metadata.json
+++ b/vm-ui-plugin/metadata.json
@@ -1,5 +1,4 @@
 {
-    "desktop-plugin-version": "1.0.0-beta.1",
     "name":"volume-sample",
     "provider": "Docker Inc.",
     "vm": {

--- a/volumes-share/server/metadata.json
+++ b/volumes-share/server/metadata.json
@@ -1,5 +1,4 @@
 {
-  "desktop-plugin-version": "1.0.0-beta.1",
   "name": "volumes-share",
   "provider": "Docker Inc.",
   "vm": {


### PR DESCRIPTION
Replaced by image label com.docker.desktop.extension.api.version

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>