### PR TITLE
Deploy docs with GHA

### DIFF
--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -1,0 +1,38 @@
+name: Build and Deploy to Netlify
+on:
+  release:
+    types: [published] # a release, pre-release, or draft of a release is published
+
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch"
+        required: true
+        default: "main"
+      tag:
+        description: "Release Tag"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build the Docs
+        uses: addnab/docker-run-action@v3
+        with:
+          image: squidfunk/mkdocs-material:latest
+          options: -v ${{ github.workspace }}:/docs
+          run: build
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: "./site"
+          production-deploy: true
+          production-branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions. Commit: ${{ github.sha }}"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_DOCKER_EXTENSIONS_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_DOCKER_EXTENSIONS_SITE_ID }}
+        timeout-minutes: 3


### PR DESCRIPTION
With this GH workflow, we can automatically deploy the docs to Netlify every time a new release is published, or manually if necessary.

Note: I've added the following secrets to the repo:

- `NETLIFY_DOCKER_EXTENSIONS_AUTH_TOKEN`
- `NETLIFY_DOCKER_EXTENSIONS_SITE_ID`