### PR TITLE
Add sample about docker theme, move up design docs

### DIFF
--- a/docs/design/design-overview.md
+++ b/docs/design/design-overview.md
@@ -1,6 +1,28 @@
 #  UI Guidelines
 
-We are currently in the process of developing our design system but in the meantime, here are some [UI guidelines](https://www.figma.com/file/U7pLWfEf6IQKUHLhdateBI/Docker-Design-Guidelines?node-id=1%3A28771). Docker Desktop's UI is written in React and [Material-UI](https://mui.com/), and we strongly recommend adopting this combination in your extensions as well. This brings the benefit of using our [Material-UI Theme](https://www.npmjs.com/package/@docker/docker-mui-theme) to easily replicate Docker Desktop's look & feel, and we'll continue to release libraries and utilities targeting this combination.
+We are currently in the process of developing our design system but in the meantime, here are some [UI guidelines](https://www.figma.com/file/U7pLWfEf6IQKUHLhdateBI/Docker-Design-Guidelines?node-id=1%3A28771). 
+
+# Using Docker Material UI Theme
+
+Docker Desktop's UI is written in React and [Material-UI](https://mui.com/), and we strongly recommend adopting this combination in your extensions as well. 
+
+This brings the benefit of using our [Docker Material UI Theme](https://www.npmjs.com/package/@docker/docker-mui-theme) to easily replicate Docker Desktop's look & feel, and we'll continue to release libraries and utilities targeting this combination.
+
+To use [Docker Material UI Theme](https://www.npmjs.com/package/@docker/docker-mui-theme) with your extension, you can wrap your react app like this: 
+
+```typescript
+import { DockerMuiThemeProvider } from '@docker/docker-mui-theme';
+import CssBaseline from '@mui/material/CssBaseline';
+
+function App() {
+  return (
+    <DockerMuiThemeProvider>
+      <CssBaseline />
+      // Your extension app here
+    </DockerMuiThemeProvider>
+  );
+}
+```
 
 # Design Principles
 At Docker we are developer obsessed, which means that we intend to build tools that can be seamlessly integrated into their workflow rather than them having to change their workflow in order to use the tool. Here are a few design principles that have facilitated us to do this and would strongly recommend that you take them into consideration when building extensions.

--- a/docs/extensions/style.md
+++ b/docs/extensions/style.md
@@ -1,3 +1,0 @@
-There is no javascript library for styling your Desktop extension available yet.
-
-You can refer to these [Design Guidelines](https://www.figma.com/file/dN4zbIrySXl2Q9SdotIwXH/Design-Guidelines?node-id=1%3A4) to start adding style to your Desktop extension.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,19 +45,18 @@ nav:
       - Create a minimal extension invoking docker commands: tutorials/minimal-frontend-using-docker-cli.md
       - Create a minimal backend extension: tutorials/minimal-backend-extension.md
       - Create a ReactJS-based extension: tutorials/react-extension.md
+  - Design Guidelines:
+      - Overview: design/design-overview.md
   - Extensions:
       - Metadata: extensions/METADATA.md
       - Labels: extensions/labels.md
       - Validation: extensions/validation.md
       - Distribution: extensions/DISTRIBUTION.md
-      - Style customization: extensions/style.md
       - Samples:
           - SwimmingWhale: extensions/samples/swimmingwhale/README.md
           - Telepresence: extensions/samples/telepresence/README.md
           - VM UI: extensions/samples/vm-ui/README.md
           - Volumes share: extensions/samples/volumes-share/README.md
-  - Design Guidelines:
-      - Overview: design/design-overview.md
   - Developer guide:
       - Overview: dev/overview.md
       - CLI:


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

* Make design section more visible in docs
* give explicit example to use Docker MUI Theme
* remove updated section

<img width="979" alt="Screenshot 2022-02-26 at 22 23 25" src="https://user-images.githubusercontent.com/437958/155948382-1968eb10-a3d5-405c-accb-b93d226880b0.png">