### PR TITLE
Add details labels to the docs

### DIFF
--- a/docs/extensions/labels.md
+++ b/docs/extensions/labels.md
@@ -1,4 +1,4 @@
-Labels are specified in the extension's `Dockerfile` and are use to provide information about the extension.
+[Labels](https://docs.docker.com/engine/reference/builder/#label) are specified in the extension's `Dockerfile` and are use to provide information about the extension.
 
 | Label <div style="width:300px"></div>| Required | Description | Example |
 | ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------ | |


### PR DESCRIPTION
`docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material`

Visit: http://0.0.0.0:8000/extensions/labels/

![image](https://user-images.githubusercontent.com/15997951/162187624-346e9328-e6c3-41aa-ae21-c0921989ab7d.png)
