### PR TITLE
Add doc for the changelog label

### DIFF
--- a/docs/extensions/labels.md
+++ b/docs/extensions/labels.md
@@ -22,7 +22,7 @@
 !!! info "HTML content styling"
 
     Docker Desktop CSS styles will be applied to the provided HTML content. You can make sure that it renders nicely
-    within the marketplace. We recommend that you follow our [CSS guidlines](../../design/design-overview/#design-principles).
+    [within the marketplace](#preview-extension-in-marketplace). We recommend that you follow our [CSS guidlines](../../design/design-overview/#design-principles).
 
 ## Preview extension in marketplace
 


### PR DESCRIPTION

<img width="862" alt="Screenshot 2022-04-20 at 20 52 41" src="https://user-images.githubusercontent.com/212269/164302254-9863dfdf-95c9-4916-bed3-b7dd29ea8965.png">


This PR follows https://github.com/docker/pinata/pull/17806

I have added:
* `com.docker.extension.changelog` in the list of available labels
* add recommendation for HTML content