### PR TITLE
Improve beta notice for extensions SDK

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,10 @@ keywords: Docker, Extensions, sdk
 
 Use the resources in this section to create your own Docker Extension.
 
-> This work is experimental and still in progress. The features and APIs detailed below are subject to change.
-> {: .warning}
+> Beta
+>
+> The Docker Extensions SDK is currently in Beta.
+> Features and APIs detailed below are subject to change.
 
 ## Overview
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

Align with notice on http://localhost:4000/desktop/extensions/
(that should be changed to "Beta" instead of "preview" soon)