### PR TITLE
docs: fix some markdown formatting issues

### DIFF
--- a/docs/dev/api/docker.md
+++ b/docs/dev/api/docker.md
@@ -49,7 +49,7 @@ const result = await ddClient.docker.cli.exec("info", [
 
 The result contains both the standard output and the standard error of the executed command:
 
-```
+```json
 {
   "stderr": "...",
   "stdout": "..."

--- a/docs/dev/cli/build-test-install-extension.md
+++ b/docs/dev/cli/build-test-install-extension.md
@@ -15,14 +15,14 @@ The `docker extension` commands are carried out by the Extension CLI which is a 
 To build the extension, run:
 
 ```console
-make extension
+$ make extension
 # or docker build -t my-extension .
 ```
 
 To install the extension, run:
 
 ```console
-docker extension install my-extension
+$ docker extension install my-extension
 ```
 
 > Using the CLI to install unpublished extensions
@@ -33,7 +33,7 @@ docker extension install my-extension
 To list all your installed extensions, run:
 
 ```console
-docker extension ls
+$ docker extension ls
 
 ID                              PROVIDER            VERSION             UI                   VM                  HOST
 docker/hub-explorer-extension   Docker Inc.         0.0.2               1 tab(Explore Hub)   Running(1)          1 binarie(s)
@@ -43,11 +43,11 @@ tailscale/docker-extension      Tailscale Inc.      0.0.2               1 tab(Ta
 To remove the extension, run:
 
 ```console
-docker extension rm my-extension
+$ docker extension rm my-extension
 ```
 
 To update an extension with a newer version (local or remote image), run:
 
 ```console
-docker extension update docker/hub-explorer-extension:0.0.3
+$ docker extension update docker/hub-explorer-extension:0.0.3
 ```

--- a/docs/dev/overview.md
+++ b/docs/dev/overview.md
@@ -23,14 +23,14 @@ For further inspiration, see the other examples in the [samples folder](https://
 In order to open the Chrome Dev Tools for your extension when you click on the extension tab, run:
 
 ```console
-docker extension dev debug my-extension
+$ docker extension dev debug my-extension
 ```
 
 Each subsequent click on the extension tab will also open Chrome Dev Tools.
 To stop this behaviour, run:
 
 ```console
-docker extension dev reset my-extension
+$ docker extension dev reset my-extension
 ```
 
 After an extension is deployed, it is also possible to open the Chrome Dev Tools from the UI extension part using a variation of the [Konami Code](https://en.wikipedia.org/wiki/Konami_Code).
@@ -43,7 +43,7 @@ For this you need to first install the extension.
 If you then run a development server locally, with `yarn start` for example, enter the following command:
 
 ```console
-docker extension dev ui-source my-extension http://localhost:8080
+$ docker extension dev ui-source my-extension http://localhost:8080
 ```
 
 This changes the source of the extension UI to your local development server. Auto and hot-reload now work.
@@ -53,7 +53,7 @@ This changes the source of the extension UI to your local development server. Au
 Once finished, you can reset the extension configuration to the original settings. This will also reset opening Chrome dev tools if you used `docker extension dev debug my-extension`:
 
 ```console
-docker extension dev reset my-extension
+$ docker extension dev reset my-extension
 ```
 
 ## Show the extension containers

--- a/docs/extensions/validation.md
+++ b/docs/extensions/validation.md
@@ -9,7 +9,7 @@ keywords: Docker, extensions, sdk, validation
 The Extensions CLI lets you validate your extension before installing and running it locally:
 
 ```console
-docker extension validate my-extension
+$ docker extension validate my-extension
 ```
 
 It checks the content of the image and ensures the image has the right labels needed for extensions.
@@ -17,7 +17,7 @@ It checks the content of the image and ensures the image has the right labels ne
 Before the image is built, it is also possible to validate only the metadata.json file:
 
 ```console
-docker extension validate /path/to/metadata.json
+$ docker extension validate /path/to/metadata.json
 ```
 
 ## JSON schema
@@ -26,4 +26,4 @@ The JSON schema used to validate the `metadata.json` file against can be found u
 
 ## Labels
 
-See [labels.](labels.md)
+See [labels](labels.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,47 +45,47 @@ In your terminal, run:
 <div class="tab-content">
   <div id="prereq-macos-intel" class="tab-pane fade in active" markdown="1">
     
-    ```console
-    tar -xvzf desktop-extension-cli-darwin-amd64.tar.gz
-    mkdir -p ~/.docker/cli-plugins
-    mv docker-extension ~/.docker/cli-plugins
-    ```
+```console
+$ tar -xvzf desktop-extension-cli-darwin-amd64.tar.gz
+$ mkdir -p ~/.docker/cli-plugins
+$ mv docker-extension ~/.docker/cli-plugins
+```
 
   <hr></div>
   <div id="prereq-macos-m1" class="tab-pane fade" markdown="1">
     
-    ```console
-    tar -xvzf desktop-extension-cli-darwin-arm64.tar.gz
-    mkdir -p ~/.docker/cli-plugins
-    mv docker-extension ~/.docker/cli-plugins
-    ```
+```console
+$ tar -xvzf desktop-extension-cli-darwin-arm64.tar.gz
+$ mkdir -p ~/.docker/cli-plugins
+$ mv docker-extension ~/.docker/cli-plugins
+```
 
   <hr></div>
   <div id="prereq-windows" class="tab-pane fade" markdown="1">
     
-    ```powershell
-    tar -xvzf desktop-extension-cli-windows-amd64.tar.gz
-    mkdir -p ~/.docker/cli-plugins
-    mv docker-extension.exe ~/.docker/cli-plugins
-    ```
+```console
+PS> tar -xvzf desktop-extension-cli-windows-amd64.tar.gz
+PS> mkdir -p ~/.docker/cli-plugins
+PS> mv docker-extension.exe ~/.docker/cli-plugins
+```
 
   <hr></div>
   <div id="prereq-wsl2" class="tab-pane fade" markdown="1">
     
-    ```console
-    tar -xvzf desktop-extension-cli-linux-amd64.tar.gz
-    mkdir -p ~/.docker/cli-plugins
-    mv docker-extension ~/.docker/cli-plugins
-    ```
+```console
+$ tar -xvzf desktop-extension-cli-linux-amd64.tar.gz
+$ mkdir -p ~/.docker/cli-plugins
+$ mv docker-extension ~/.docker/cli-plugins
+```
 
   <hr></div>
   <div id="prereq-linux" class="tab-pane fade" markdown="1">
 
-    ```console
-    tar -xvzf desktop-extension-cli-linux-amd64.tar.gz
-    mkdir -p ~/.docker/cli-plugins
-    mv docker-extension ~/.docker/cli-plugins
-    ```
+```console
+$ tar -xvzf desktop-extension-cli-linux-amd64.tar.gz
+$ mkdir -p ~/.docker/cli-plugins
+$ mv docker-extension ~/.docker/cli-plugins
+```
 
   <hr></div>
 </div>
@@ -93,7 +93,7 @@ In your terminal, run:
 You can now list installed extensions (the list should be empty if you have not installed extensions already):
 
 ```console
-docker extension ls
+$ docker extension ls
 ID                  PROVIDER            VERSION             UI                  VM                  HOST
 ```
 


### PR DESCRIPTION
- fix indentation for some code-blocks
- make sure console examples have a prompt so that they're highlighted
  correctly, and to allow copy/paste.


Before:

<img width="999" alt="Screenshot 2022-05-05 at 09 18 49" src="https://user-images.githubusercontent.com/1804568/166878054-efb47646-8458-4907-a8e2-d65a3dd7970d.png">



After:

<img width="997" alt="Screenshot 2022-05-05 at 09 18 34" src="https://user-images.githubusercontent.com/1804568/166878073-0dd2864a-44e9-4a0b-b09d-92e36f836c55.png">

