### PR TITLE
Add config files for auto-formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2

--- a/.prettierrc.json5
+++ b/.prettierrc.json5
@@ -1,0 +1,5 @@
+// This file explicitly configures prettier to use its default settings if no
+// more specific config file is found. It prevents it from detecting config files
+// in ancestor directories, to ensure that the formatting is consistent regardless
+// of the user's directory structure.
+{}


### PR DESCRIPTION
Prettier was applying my personal config when I was editing files in this repo. Let's have some explicit config (matching our other repos) to keep us aligned.