### PR TITLE
docs: fix incorrect make command

### DIFF
--- a/docs/dev/cli/build-test-install-extension.md
+++ b/docs/dev/cli/build-test-install-extension.md
@@ -15,7 +15,7 @@ The `docker extension` commands are carried out by the Extension CLI which is a 
 To build the extension, run:
 
 ```console
-$ make extension
+$ make build-extension
 # or docker build -t my-extension .
 ```
 


### PR DESCRIPTION
Correct command is `build-extension`.

![Screen Shot 2022-05-11 at 23 37 29](https://user-images.githubusercontent.com/16493751/167943394-2540ec7f-b380-4d1c-816f-db5686f05358.png)
