### PR TITLE
Redirect Netlify site to Docker SDK docs

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,0 +1,5 @@
+# Redirects from what the browser requests to what we serve
+
+# See https://docs.netlify.com/routing/redirects/
+
+/ https://docs.docker.com/desktop/extensions-sdk/


### PR DESCRIPTION
Notice that the `_redirects` file must be placed in the [publish directory](https://docs.netlify.com/configure-builds/overview/#basic-build-settings) of the site.

When building the site, the `_redirects` file is added:

![image](https://user-images.githubusercontent.com/15997951/168778461-242bf9ec-7854-4f30-b6e8-561694af8974.png)
