### PR TITLE
Add github CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @docker/content-publisher-backend @docker/publisher-ui


### PR DESCRIPTION
So the Dockerfile is analysed by Scout (https://docker.atlassian.net/browse/ECOPUB-514), but also good practice for repos.

- [ ] Could someone add content-publisher-backend team to repo admins please.